### PR TITLE
Add NOTIFICATION method to send any notification to modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Menu to change the `config.js`
     - Modules can be installed, added, removed, configured
     - There will be backups of the five last versions of the `config.js` in the `config` folder
+- NOTIFICATION action, see [README.md](README.md#notification-request) for details
 
 ### Changed
 - Smaller font sizes in lists

--- a/MMM-Remote-Control.js
+++ b/MMM-Remote-Control.js
@@ -115,6 +115,9 @@ Module.register("MMM-Remote-Control", {
 				}
 			}
 		}
+		if (notification === "NOTIFICATION") {
+			this.sendNotification(payload.notification, payload.payload);
+		}
 	},
 
 	buildCssContent: function(brightness) {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ this.sendNotification('REMOTE_ACTION', {action: 'RESTART'});
 | SHOW_ALERT | Show Default Alert/Notification |
 | HIDE_ALERT | Hide Default Alert/Notification |
 | UPDATE | Update MagicMirror and any of it's modules |
+| NOTIFICATION | Send a notification to all modules (see [Notification Request](#notification-request)). |
 
 ### Format of module data response
 
@@ -92,6 +93,27 @@ The response will be in the JSON format, here is an example:
 "brightness":40,
 "settingsVersion":1
 }
+```
+
+### Notification Request
+
+To send a notification to all modules, send the following GET-parameters.
+
+| key | value |
+| --- | ----- |
+| action | `NOTIFICATION`<br>**Required** |
+| notification | The notification to send, e.g. `ARTICLE_MORE_DETAILS`, `SHOW_ALERT` or `HIDE_ALERT`.<br>**Required** |
+| payload | A stringified JSON object with the payload for the notification.<br>**Optional** if absent, an empty payload (`{}`) is assumed. |
+
+Examples:
+
+```
+?action=NOTIFICATION&notification=ARTICLE_MORE_DETAILS
+
+?action=NOTIFICATION&notification=SHOW_ALERT&payload={%22title%22:%22Alert%22,%22message%22:%22This%20is%an%20alert.%22}
+(Payload is URL-encoded form of {"title":"Alert","message":"This is an alert."})
+
+?action=NOTIFICATION&notification=HIDE_ALERT
 ```
 
 ## License

--- a/node_helper.js
+++ b/node_helper.js
@@ -655,6 +655,25 @@ module.exports = NodeHelper.create({
 			self.updateModule(decodeURI(query.module), res);
 			return true;
 		}
+		if (query.action === 'NOTIFICATION')
+		{
+			try {
+				var payload = {}; // Assume empty JSON-object if no payload is provided
+				if (typeof query.payload === 'undefined') {
+					payload = query.payload;
+				} else {
+					payload = JSON.parse(query.payload);
+				}
+
+				this.sendSocketNotification(query.action, {'notification': query.notification, 'payload': payload});
+				res.send({'status': 'success'});
+				return true;
+			} catch(err) {
+				console.log("ERROR: ", err);
+				res.send({'status': err.message});
+				return true;
+			}
+		}
 		return false;
 	},
 
@@ -833,6 +852,7 @@ module.exports = NodeHelper.create({
 			// check if we have got saved default settings
 			self.loadDefaultSettings();
 		}
+
 		if (notification === "REMOTE_ACTION")
 		{
 			this.executeQuery(payload);


### PR DESCRIPTION
As specified in the README:

To send a notification to all modules, send the following GET-parameters.

| key | value |
| --- | ----- |
| action | `NOTIFICATION`<br>**Required** |
| notification | The notification to send, e.g. `ARTICLE_MORE_DETAILS`, `SHOW_ALERT` or `HIDE_ALERT`.<br>**Required** |
| payload | A stringified JSON object with the payload for the notification.<br>**Optional** if absent, an empty payload (`{}`) is assumed. |

Examples:

```
?action=NOTIFICATION&notification=ARTICLE_MORE_DETAILS

?action=NOTIFICATION&notification=SHOW_ALERT&payload={%22title%22:%22Alert%22,%22message%22:%22This%20is%an%20alert.%22}
(Payload is URL-encoded form of {"title":"Alert","message":"This is an alert."})

?action=NOTIFICATION&notification=HIDE_ALERT
```

This might obsolete the SHOW_ALERT and HIDE_ALERT, though you could those for easier access. The addedd value of the NOTIFICATION action is that it provides a generic call for any module, so you don't have to update your MMM-Remote-Control code for all modules out there and people can still use it to send notifications from external systems.

I would like to use this myself to send actions from my [Pimatic](https://pimatic.org) instance. Together with my [MMM-pimatic](https://github.com/qistoph/MMM-pimatic) this allows full integration in both ways, Pimatic ⇆ MagicMirror.