### PR TITLE
Fix error on MM update to enable restart button

### DIFF
--- a/remote.js
+++ b/remote.js
@@ -1467,7 +1467,7 @@ var buttons = {
 
     // update Menu
     "update-mm-button": function () {
-        Remote.getWithStatus("action=UPDATE");
+        Remote.updateModule(undefined);
     },
 
     // alert menu


### PR DESCRIPTION
Updating MagicMirror itself through the remote control will update the git repo, but it doesn't offer the restart button.

This PR uses a slightly different call to update MagicMirror which enables a user to subsequently click the restart button.