### PR TITLE
Fix bad brace in socketNotificationReceived function

### DIFF
--- a/MMM-Remote-Control.js
+++ b/MMM-Remote-Control.js
@@ -55,12 +55,14 @@ Module.register("MMM-Remote-Control", {
     socketNotificationReceived: function(notification, payload) {
         if (notification === "UPDATE") {
             this.sendCurrentData();
-            if (notification === "IP_ADDRESSES") {}
+        }  
+        if (notification === "IP_ADDRESSES") {
             this.addresses = payload;
             if (this.data.position) {
                 this.updateDom();
             }
         }
+        
         if (notification === "USER_PRESENCE") {
             this.sendNotification(notification, payload);
         }


### PR DESCRIPTION
There has been an issue since e0e2beb513baa9720e8acae22bc6995d2b32b0c3 that has caused the IP to not update when loading the modules.

This patch fixes it by moving the brace back to the proper position.