### PR TITLE
API: Add POST support to /api/monitor

### DIFF
--- a/API/api.js
+++ b/API/api.js
@@ -231,10 +231,9 @@ module.exports = {
             .post((req, res) => {
                 var actionName = "STATUS";
                 if (typeof req.body !== 'undefined' && "monitor" in req.body) {
-                    if (req.body.monitor === "off" || !req.body.monitor) {
-                        actionName = "OFF";
-                    } else {
-                        actionName = "ON";
+                    switch(req.body.monitor){
+                        case 'off': case 'OFF': actionName = "OFF"; break;
+                        case 'on': case 'ON': actionName = "ON"; break;
                     }
                 }
                 this.executeQuery(this.checkDelay({ action: `MONITOR${actionName}` }, req), res);

--- a/API/api.js
+++ b/API/api.js
@@ -227,6 +227,17 @@ module.exports = {
                 if (!req.params.action) { req.params.action = "STATUS"; }
                 var actionName = req.params.action.toUpperCase();
                 this.executeQuery(this.checkDelay({ action: `MONITOR${actionName}` }, req), res);
+            })
+            .post((req, res) => {
+                var actionName = "STATUS";
+                if (typeof req.body !== 'undefined' && "monitor" in req.body) {
+                    if (req.body.monitor === "off" || !req.body.monitor) {
+                        actionName = "OFF";
+                    } else {
+                        actionName = "ON";
+                    }
+                }
+                this.executeQuery(this.checkDelay({ action: `MONITOR${actionName}` }, req), res);
             });
 
         this.expressRouter.route('/brightness/:setting(\\d+)')

--- a/node_helper.js
+++ b/node_helper.js
@@ -858,8 +858,6 @@ module.exports = NodeHelper.create(Object.assign({
         },
 
         checkForExecError: function(error, stdout, stderr, res, data) {
-            console.log(stdout);
-            console.log(stderr);
             this.sendResponse(res, error, data);
         },
 


### PR DESCRIPTION
Makes /api/monitor more like a REST resource, which can be read
with GET or changed with POST and a JSON body {"monitor": "on"}.
This is convenient for interfacing with services like Homeassistant
RESTful Switch which wants a single resource name.