### PR TITLE
Adds restart process logic inside controlPm2 of node_helper.js

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -874,11 +874,19 @@ module.exports = NodeHelper.create(Object.assign({
                 }
                 console.log(`PM2 process: ${query.action.toLowerCase()} ${processName}`);
 
-                pm2.stop(processName, (err, apps) => {
-                    this.sendResponse(res, undefined, { action: action, processName: processName });
-                    pm2.disconnect();
-                    if (err) { this.sendResponse(res, err); }
-                });
+                if(query.action === "RESTART"){
+                	pm2.restart(processName, (err, apps) => {
+                		this.sendResponse(res, undefined, { action: action, processName: processName });
+                    	pm2.disconnect();
+                    	if (err) { this.sendResponse(res, err); }
+                	});
+                } else {
+                	pm2.stop(processName, (err, apps) => {
+                    	this.sendResponse(res, undefined, { action: action, processName: processName });
+                    	pm2.disconnect();
+                    	if (err) { this.sendResponse(res, err); }
+                	});
+                }
             });
         },
 


### PR DESCRIPTION
The function named controlPm2 inside node_helper.js(at line no. 866) only stops the process, it does not have condition(or logic) to restart the process. This adds the code for restarting the process. 