### PR TITLE
[installer.sh] Auto-detect node binary

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -145,7 +145,8 @@ else
 fi
 
 # Get an UUID to use as an API key
-APIKEY=$(/usr/local/bin/node -e 'console.log(require("uuid/v4")().replace(/-/g, ""));');
+NODE_BIN=$(which node)
+APIKEY=$($NODE_BIN -e 'console.log(require("uuid/v4")().replace(/-/g, ""));');
 
 echo ""
 if check_no "Do you want to view instructions on how to configure the module?"; then


### PR DESCRIPTION
Depending how Node.js has been installed and the packages used by the distribution, the `node` binary could be in different place which could prevent the module installation.

```
Installation finished.
bash: line 147: /usr/local/bin/node: No such file or directory

>>> Do you want to view instructions on how to configure the module? [Y/n]?
```