### PR TITLE
Merge Params with Body in API POST requests

### DIFF
--- a/API/api.js
+++ b/API/api.js
@@ -261,6 +261,10 @@ module.exports = {
             })
             .post((req, res) => {
                 if(!this.apiKey && this.secureEndpoints) return res.status(403).json({ success: false, message: "Forbidden: API Key Not Provided in Config! Use secureEndpoints to bypass this message" });
+                req.params = {
+                    ... req.params,
+                    ... req.body
+                }
                 this.answerNotifyApi(req, res);
             });
 
@@ -269,6 +273,10 @@ module.exports = {
                 this.answerModuleApi(req, res);
             })
             .post((req, res) => {
+                req.params = {
+                    ... req.params,
+                    ... req.body
+                }
                 this.answerModuleApi(req, res);
             });
 


### PR DESCRIPTION
<!--
If you publish this PR, you accept that you made your own tests, and that the program not only works, but also fixes the issue.
You should have the steps to being able to reproduce this bug, for us to check if it's truly a bug.
Please commit your contribution into the develop branch. Will be change if you don't do it.

Also, you accept that, if this Pull Request it's invalid in any way, will be discarded without receiving any response about it.
If you're not sure if it's a bug, please fill the question template on the issues templates.

You can now erase this warning, and complete the steps below. Cheers :D
-->

## Bug Fix

API resources for module control and notifications allow for POST requests, but ignore the body of the request, so they don't actually work. This merges the body and params objects to allow POST requests to work properly for these two endpoints.

<!--- You should link every issue that's fixed with this PR --->

### Steps to reproduce

Attempt to call a POST request with only body contents containng the `moduleName` and `action` to `/api/module` and you will get the default reponse of listing all modules' info. After the change, it will correctly call the action. 

### Additional info

Note this is required to allow creation of Home Assistant REST Switches to work properly for showing/hiding modules. These require the URL to be the same and only the body to change. Currently this doesn't work because you have to use GET requests to different urls.