### PR TITLE
Fix Modules API when using Identifiers

### DIFF
--- a/API/api.js
+++ b/API/api.js
@@ -344,16 +344,16 @@ module.exports = {
             return;
         }
         
-        var modData = [];
+        let modData = [];
         if(req.params.moduleName !== 'all') {
-            let i = dataMerged.find(m => {
+            modData = dataMerged.filter(m => {
                 return (req.params.moduleName.includes(m.identifier));
             });
-            if (!i) {
+            if (!modData) {
                 modData = dataMerged.filter(m => {
                     return (req.params.moduleName.includes(m.name));
                 });
-            } else modData.push(i)
+            }
         } else {
             modData = dataMerged;
         }
@@ -364,7 +364,7 @@ module.exports = {
         } 
         
         if (!req.params.action) {
-            res.json({ success: true, data: dataMerged.filter(m => req.params.moduleName.includes(m.name)) });
+            res.json({ success: true, data: modData });
             return;
         }
         


### PR DESCRIPTION
## Bug Fix

Unreported bug: Modules API would inadvertently report data or act on all modules with a matching name, even when using an module identifier as the parameter.

This PR corrects this behavior to the expected behavior of only acting on the module matching the unique identifier.

<!--- You should link every issue that's fixed with this PR --->

### Steps to reproduce

<!-- Please give details about how do you reach that behavior -->

Given multiple instances of module (e.g. calendar). Calling http://localhost:8080/api/module/module_5_calendar would return data for all calendar modules instead of just instance 5. This also caused hide/show actions to fail to act on the expected module.

### Additional info

<!-- Everything else that you think could be useful for us. ;D -->