### PR TITLE
[FR] Show header in Edit View menu, if set

### DIFF
--- a/remote.css
+++ b/remote.css
@@ -125,6 +125,10 @@ a {
 .text {
     flex: 1 1 auto;
     margin-left: 0.2em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
 }
 
 .fa-angle-right {

--- a/remote.js
+++ b/remote.js
@@ -648,6 +648,9 @@ var Remote = {
                 var text = document.createElement("span");
                 text.className = "text";
                 text.innerHTML = " " + self.formatName(moduleData[i].name);
+                if ("header" in moduleData[i]) {
+                        text.innerHTML += ` (${moduleData[i].header})`;
+                }
                 moduleBox.appendChild(text);
 
                 parent.appendChild(moduleBox);


### PR DESCRIPTION
## Feature Addition

### Description

Add the user's header text (if set) to the Edit View menu to differentiate between mutliple instances of the same module.

<img width="272" alt="image" src="https://user-images.githubusercontent.com/18057952/194198631-982a6141-fed6-4303-b88a-5a99716a1fb6.png">


### Changelog

- Update `remote.js` to conditionally add the modules' header text when building the menu.
- Update `remote.css` to enable ellipsis overflow in case the header text is too long for 1 line.

### Requirements

Data is already available. See code changes for details.

### Additional info

<!-- Everything else that you think could be useful for us. ;D -->