### PR TITLE
Add missing dependency pm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "Magic-Mirror-Module-Remote-Control",
+  "name": "mmm-remote-control",
   "version": "2.3.8",
-  "description": "This module for the Magic Mirror allows you to shutdown and configure your mirror through a web browser.",
+  "description": "This module for the MagicMirror² allows you to shutdown and configure your mirror through a web browser.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jopyth/MMM-Remote-Control"
@@ -24,6 +24,7 @@
     "body-parser": "latest",
     "lodash": "latest",
     "node-fetch": "^2.7.0",
+    "pm2": "^5.3.1",
     "simple-git": "latest",
     "uuid": "^3.3.2"
   }


### PR DESCRIPTION
This resolves an issue reported in the forum: https://forum.magicmirror.builders/topic/18486/mmm-remote-control-is-not-able-to-restart-magic-mirror

Additionally I fixed the name and a typo in the `package.json`.