### PR TITLE
fix needed for new MagicMirror² version `v2.29.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MagicMirror² Module: Remote Control w/ RESTful API
 
-This module for the [MagicMirror²](https://github.com/MichMich/MagicMirror) allows you to quickly shutdown your mirror through a web browser.
+This module for the [MagicMirror²](https://github.com/MagicMirrorOrg/MagicMirror) allows you to quickly shutdown your mirror through a web browser.
 The website should work fine on any device (desktop, smart phone, tablet, ...).
 Since we all want our [SD cards to live a long and prosper life](http://raspberrypi.stackexchange.com/a/383) we properly shut down before pulling the power plug everytime, am I right?
 Additionally you can hide and show modules on your mirror and do other cool stuff.
@@ -15,7 +15,7 @@ Additionally you can hide and show modules on your mirror and do other cool stuf
 
 ### Quick install
 
-If you followed the default installation instructions for the [MagicMirror²](https://github.com/MichMich/MagicMirror) project, you should be able to use the automatic installer.
+If you followed the default installation instructions for the [MagicMirror²](https://github.com/MagicMirrorOrg/MagicMirror) project, you should be able to use the automatic installer.
 The following command will download the installer and execute it:
 
 ```bash
@@ -54,7 +54,7 @@ npm install
 ```
 
 - (3) For security reasons, the MagicMirror² (and therefore the Remote Control) is *not* reachable externally.
-To change this, configure `address`, and `ipWhitelist` in your `config.js` (see [these lines in the sample config](https://github.com/MichMich/MagicMirror/blob/master/config/config.js.sample#L12-L22)).
+To change this, configure `address`, and `ipWhitelist` in your `config.js` (see [these lines in the sample config](https://github.com/MagicMirrorOrg/MagicMirror/blob/master/config/config.js.sample#L12-L22)).
 For example change `address` to `0.0.0.0` and add two allowed devices with IP-Adresses `192.168.0.42` and `192.168.0.50`:
 
 ```js
@@ -200,7 +200,7 @@ The response will be in the JSON format, here is an example:
 "moduleData":[
     {"hidden":false,"name":"alert","identifier":"module_0_alert"},
     {"hidden":true,"name":"clock","identifier":"module_1_clock","position":"bottom_right"},
-    {"hidden":false,"name":"currentweather","identifier":"module_2_currentweather","position":"top_right"}
+    {"hidden":false,"name":"weather","identifier":"module_2_weather","position":"top_right"}
 ],
 "brightness":40,
 "settingsVersion":1

--- a/installer.sh
+++ b/installer.sh
@@ -37,8 +37,8 @@ MM_HOME=$HOME/MagicMirror
 MODULE_NAME=MMM-Remote-Control
 FORK=Jopyth
 
-# check if we are correct by searching for https://github.com/MichMich/MagicMirror in package.json
-TEST_STRING="\"url\": \"git+https://github.com/MichMich/MagicMirror.git\""
+# check if we are correct by searching for https://github.com/MagicMirrorOrg/MagicMirror in package.json
+TEST_STRING="\"url\": \"git+https://github.com/MagicMirrorOrg/MagicMirror.git\""
 if grep -sq "$TEST_STRING" "$MM_HOME/package.json"; then
     # we found it
     echo -n ""

--- a/modules.json
+++ b/modules.json
@@ -1124,7 +1124,7 @@
     "id": "sebastianhodapp/MMM-IndoorTemp",
     "url": "https://github.com/sebastianhodapp/MMM-IndoorTemp",
     "author": "sebastianhodapp",
-    "desc": "The module emits the notification \"INDOOR_TEMPERATURE\" to display the indoor temperature received via a subscribed MQTT topic in the default [Current Weather module](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/currentweather)."
+    "desc": "The module emits the notification \"INDOOR_TEMPERATURE\" to display the indoor temperature received via a subscribed MQTT topic in the default [Weather module](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/weather)."
   },
   {
     "longname": "MMM-meteoblueCurrent",

--- a/node_helper.js
+++ b/node_helper.js
@@ -19,7 +19,7 @@ const bodyParser = require("body-parser");
 const express = require("express");
 const _ = require("lodash");
 
-var defaultModules = require(path.resolve(__dirname + "/../default/defaultmodules.js"));
+var defaultModules = require(path.resolve(__dirname + "/../../modules/default/defaultmodules.js"));
 
 Module = {
     configDefaults: {},
@@ -221,7 +221,7 @@ module.exports = NodeHelper.create(Object.assign({
                         url: "https://docs.magicmirror.builders/modules/introduction.html"
                     });
                     var module = self.modulesAvailable[self.modulesAvailable.length - 1];
-                    var modulePath = self.configOnHd.paths.modules + "/default/" + defaultModules[i];
+                    var modulePath = "modules/default/" + defaultModules[i];
                     self.loadModuleDefaultConfig(module, modulePath, i === defaultModules.length-1);
                 }
 
@@ -235,10 +235,14 @@ module.exports = NodeHelper.create(Object.assign({
             });
         },
 
+        getModuleDir() {
+            return this.configOnHd.foreignModulesDir ? this.configOnHd.foreignModulesDir : (this.configOnHd.paths ? this.configOnHd.paths.modules : "modules");
+        },
+
         addModule(folderName, lastOne) {
             var self = this;
 
-            var modulePath = this.configOnHd.paths.modules + "/" + folderName;
+            var modulePath = this.getModuleDir() + "/" + folderName;
             fs.stat(modulePath, (err, stats) => {
                 if (stats.isDirectory()) {
                     var isInList = false;
@@ -340,7 +344,7 @@ module.exports = NodeHelper.create(Object.assign({
                 });
                 return;
             }
-            var modulePath = this.configOnHd.paths.modules + "/" + query.module;
+            var modulePath = this.getModuleDir() + "/" + query.module;
             let git = simpleGit(modulePath);
             git.getRemotes(true, function(error, result) {
                 if (error) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -95,7 +95,7 @@ module.exports = NodeHelper.create(Object.assign({
         },
 
         combineConfig() {
-            // function copied from MichMich (MIT)
+            // function copied from MagicMirrorOrg (MIT)
             var defaults = require(__dirname + "/../../js/defaults.js");
             var configFilename = path.resolve(__dirname + "/../../config/config.js");
             if (typeof(global.configuration_file) !== "undefined") {
@@ -215,10 +215,10 @@ module.exports = NodeHelper.create(Object.assign({
                         name: self.capitalizeFirst(defaultModules[i]),
                         isDefaultModule: true,
                         installed: true,
-                        author: "MichMich",
+                        author: "MagicMirrorOrg",
                         desc: "",
-                        id: "MichMich/MagicMirror",
-                        url: "https://github.com/MichMich/MagicMirror/wiki/MagicMirror%C2%B2-Modules#default-modules"
+                        id: "MagicMirrorOrg/MagicMirror",
+                        url: "https://docs.magicmirror.builders/modules/introduction.html"
                     });
                     var module = self.modulesAvailable[self.modulesAvailable.length - 1];
                     var modulePath = self.configOnHd.paths.modules + "/default/" + defaultModules[i];
@@ -307,7 +307,7 @@ module.exports = NodeHelper.create(Object.assign({
         },
 
         loadModuleDefaultConfig(module, modulePath, lastOne) {
-            // function copied from MichMich (MIT)
+            // function copied from MagicMirrorOrg (MIT)
             var filename = path.resolve(modulePath + "/" + module.longname + ".js");
             try {
                 fs.accessSync(filename, fs.F_OK);
@@ -335,7 +335,7 @@ module.exports = NodeHelper.create(Object.assign({
                     if (error) {
                         Log.error(error);
                     }
-                    res.writeHead(302, { 'Location': "https://github.com/MichMich/MagicMirror/tree/" + result.trim() + "/modules/default/" + query.module });
+                    res.writeHead(302, { 'Location': "https://github.com/MagicMirrorOrg/MagicMirror/tree/" + result.trim() + "/modules/default/" + query.module });
                     res.end();
                 });
                 return;

--- a/scripts/download_modules.js
+++ b/scripts/download_modules.js
@@ -20,7 +20,7 @@ const util = require("util");
 var downloadModules = {
     defaults: {
         modulesFile: path.resolve(__dirname, "../modules.json"),    // Path to modules file
-        sourceUrl: 'https://raw.githubusercontent.com/wiki/MichMich/MagicMirror/3rd-Party-Modules.md', // Source url
+        sourceUrl: 'https://raw.githubusercontent.com/wiki/MagicMirrorOrg/MagicMirror/3rd-Party-Modules.md', // Source url
         refreshRate: 24 * 3600,                                     // Max Refresh of One Day
         force: false,                                               // Force the update
         callback: function(result) { console.log(result); }         // Callback to run on success or failure

--- a/scripts/download_modules.py
+++ b/scripts/download_modules.py
@@ -71,7 +71,7 @@ def main(args):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='command line utility to download current modules')
-    parser.add_argument('-u', '--url', nargs='?', default='https://raw.githubusercontent.com/wiki/michmich/MagicMirror/MagicMirror%C2%B2-Modules.md', help='url to extract modules from')
+    parser.add_argument('-u', '--url', nargs='?', default='https://raw.githubusercontent.com/wiki/MagicMirrorOrg/MagicMirror/3rd-Party-Modules.md', help='url to extract modules from')
     parser.add_argument('-o', '--outfile', nargs='?', type=argparse.FileType('w'), default=sys.stdout, help='write output to a file (default stdout)')
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR contains 2 things:
- update outdated url's
- fixes for new MagicMirror² version `v2.29.0`

In `v2.29.0` we changed some config settings, `config.paths.modules` was replaced by `config.foreignModulesDir` for foreign modules (for default modules you must use the hardcoded `modules/default`). For more info see https://github.com/MagicMirrorOrg/MagicMirror/releases/tag/v2.29.0.

Without this fix MMM-Remote-Control is broken and will not work with MagicMirror² version >= `v2.29.0`.