### PR TITLE
Fix installer.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.x.x] - UNRELEASED
+
+### Fixed
+
+- Updated TEST_STRING in `installer.sh`. Since MagicMirror² v2.27.0, the string has changed and the installer script was not able to detect the MagicMirror² directory.
+
 ## [2.5.0] - 2024-11-20
 
 ### Added

--- a/installer.sh
+++ b/installer.sh
@@ -38,7 +38,7 @@ MODULE_NAME=MMM-Remote-Control
 FORK=Jopyth
 
 # check if we are correct by searching for https://github.com/MagicMirrorOrg/MagicMirror in package.json
-TEST_STRING="\"url\": \"git+https://github.com/MagicMirrorOrg/MagicMirror.git\""
+TEST_STRING="\"url\": \"https://github.com/MagicMirrorOrg/MagicMirror\""
 if grep -sq "$TEST_STRING" "$MM_HOME/package.json"; then
     # we found it
     echo -n ""

--- a/installer.sh
+++ b/installer.sh
@@ -196,7 +196,7 @@ fi
 echo "Have fun with the module, if you have any problems, please search for help on github or in the forum:"
 echo ""
 echo "   Github : https://github.com/$FORK/$MODULE_NAME"
-echo "   Forum  : http://forum.magicmirror.builders"
+echo "   Forum  : https://forum.magicmirror.builders"
 echo ""
 echo "Do not forget to restart your MagicMirror² to activate the module! Installation finished."
 echo ""


### PR DESCRIPTION
Since MagicMirror² v2.27.0, the string has changed and the installer script was not able to detect the MagicMirror² directory.

https://github.com/MagicMirrorOrg/MagicMirror/compare/v2.26.0...v2.27.0