### PR TITLE
Release 2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.5.0] - Unreleased (`develop` branch)
+## [2.5.0] - 2024-11-20
 
 ### Added
 
 - Added a spell checker and fixed problems that were found (#308).
-- Added JavaScript linting (for the start with soft rules).
-- Added GitHub workflow for linting and spell checking on every push and pull request.
+- Added JavaScript linting (for the start with soft rules) (#310).
+- Added GitHub workflow for linting and spell checking on every push and pull request (#310).
+- Added Turkish language (#305)
 
 ## [2.4.0] - 2024-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [2.x.x] - UNRELEASED
+## [2.5.1] - 2024-12-17
 
 ### Fixed
 
-- Updated TEST_STRING in `installer.sh`. Since MagicMirror² v2.27.0, the string has changed and the installer script was not able to detect the MagicMirror² directory.
+- An error in the installation script. (Since MagicMirror² v2.27.0, the string used as TEST_STRING in `installer.sh` has changed and the installer script was not able to detect the MagicMirror² directory.)
 
 ## [2.5.0] - 2024-11-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Magic-Mirror-Module-Remote-Control",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "This module for the MagicMirror allows you to shutdown and configure your mirror through a web browser.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Magic-Mirror-Module-Remote-Control",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "This module for the MagicMirror allows you to shutdown and configure your mirror through a web browser.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## [2.5.1] - 2024-12-17

### Fixed

- An error in the installation script. (Since MagicMirror² v2.27.0, the string used as TEST_STRING in `installer.sh` has changed and the installer script was not able to detect the MagicMirror² directory.)