### PR TITLE
[Bug fix] Solve issue when not using standard config file

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -98,7 +98,7 @@ module.exports = NodeHelper.create(Object.assign({
             const defaults = require(__dirname + "/../../js/defaults.js");
             let configFilename = path.resolve(__dirname + "/../../config/config.js");
             if (typeof(global.configuration_file) !== "undefined") {
-                configFilename = global.configuration_file;
+                configFilename = path.resolve(__dirname + "/../../"+global.configuration_file);
             }
 
             this.thisConfig = {};


### PR DESCRIPTION
MagicMirror allows you to define a different config file using the MM_CONFIG_FILE env variable. If you do this, `MMM-Remote-Control` won't be able to find the config file and will output this error message:

`[ERROR] MMM-Remote-Control WARNING! Could not load config file. Starting with default configuration. Error found: Error: Cannot find module 'config/config2.js'`

This will fix the issue.