### PR TITLE
Fix: Add ALL_MODULES_STARTED fallback for missed DOM_OBJECTS_CREATED

### DIFF
--- a/MMM-Remote-Control.js
+++ b/MMM-Remote-Control.js
@@ -63,6 +63,14 @@ Module.register("MMM-Remote-Control", {
     Log.debug(`${this.name} received a module notification: ${notification} from sender: ${sender}`);
     switch (notification) {
       case "DOM_OBJECTS_CREATED":
+      // Fallback: DOM_OBJECTS_CREATED can occasionally fire before this module
++     // has fully registered as a notification listener (race condition seen with
++     // newer Node.js/Electron versions), causing the event to be missed and the
++     // module to stay permanently "not initialized". ALL_MODULES_STARTED is
++     // received reliably afterwards and acts as a safety net.
++     case "ALL_MODULES_STARTED":
++       if (this.currentDataSent) { break; }
++       this.currentDataSent = true;
         this.sendSocketNotification("REQUEST_DEFAULT_SETTINGS");
         this.sendCurrentData();
         break;


### PR DESCRIPTION
## Problem
`DOM_OBJECTS_CREATED` can occasionally be missed by this module if it fires before 
the module has fully registered as a notification listener. This appears to be a 
race condition that surfaced with newer Node.js/Electron versions (tested on 
Node 22.22.2, MagicMirror 2.37.0, Debian 13). When missed, `sendCurrentData()` is 
never called, `this.initialized` stays `false` on the backend forever, and every 
API call fails with "Not initialized, have you opened or refreshed your browser...".

## Fix
Adds `ALL_MODULES_STARTED` as a fallback trigger alongside `DOM_OBJECTS_CREATED`, 
since it's received reliably in all tested cases. A `currentDataSent` flag prevents 
`sendCurrentData()` from running twice if both notifications do arrive.

## Testing
Verified on a Raspberry Pi 4B (Debian 13, Node 22.22.2, MagicMirror 2.37.0) where 
the original bug reproduced consistently, and the fix resolved it reliably across 
multiple restarts.
